### PR TITLE
add extraRuns option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,5 @@ Options
 * `latex.skipBuild=true|false` for skipping the build, default: `false`
 * `latex.forceBuild=true|false` for forcing the build, default: `false`
 * `latex.dummyBuild=true|false` for creating dummy PDFs (eg if no LaTeX present), default: `false`
+* `latex.extraRuns=...` to run pdflatex more times than normal, default: `0`
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ For your `pom.xml`:
               </goals>
             </execution>
           </executions>
+          <configuration>
+            <forceBuild>true</forceBuild>
+          </configuration>
         </plugin>
         ...
       </plugins>

--- a/latex-maven-plugin/pom.xml
+++ b/latex-maven-plugin/pom.xml
@@ -91,7 +91,7 @@
         <configuration>
           <show>private</show>
           <nohelp>true</nohelp>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <additionalparam>${javadoc.opts}</additionalparam>
         </configuration>
       </plugin>
     </plugins>
@@ -130,6 +130,15 @@
   </properties>
 
   <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
     <profile>
       <id>latex-integration-test</id>
       <activation>

--- a/latex-maven-plugin/src/main/java/org/codehaus/mojo/latex/LaTeXMojo.java
+++ b/latex-maven-plugin/src/main/java/org/codehaus/mojo/latex/LaTeXMojo.java
@@ -188,6 +188,13 @@ public class LaTeXMojo
      */
     private boolean dummyBuild;
 
+    /**
+     * Extra times to run pdflatex. Useful to get references right.
+     *
+     * @parameter expression="${latex.extraRuns}" default-value="0"
+     */
+    private int extraRuns;
+
     public void execute()
         throws MojoExecutionException, MojoFailureException
     {
@@ -293,7 +300,11 @@ public class LaTeXMojo
                     execute( bibTeX, dir );
                     execute( pdfLaTeX, dir );
                 }
-                execute( pdfLaTeX, dir );
+
+                for ( int runs = extraRuns + 1; runs > 0; runs-- )
+                {
+                    execute( pdfLaTeX, dir );
+                }
 
                 copyFile( pdfFile, new File( buildDir, pdfFile.getName() ) );
             }


### PR DESCRIPTION
This patch adds an extraRuns option, which is often useful if you need to run `pdflatex` more often than just twice to get all cross references right, e.g. when [using `marginnote` inside a `minipage`](http://tex.stackexchange.com/a/284190/43807).

The other two commits are really trivial: make it buildable with Java 7, and add an example of how to set configuration options to the README.
