### PR TITLE
add makeglossaries (and, to be safe, bibtex) runs into the loop

### DIFF
--- a/latex-maven-plugin/src/main/java/org/codehaus/mojo/latex/LaTeXMojo.java
+++ b/latex-maven-plugin/src/main/java/org/codehaus/mojo/latex/LaTeXMojo.java
@@ -302,18 +302,17 @@ public class LaTeXMojo
                 }
 
                 execute( pdfLaTeX, dir );
-                if ( gloFile.exists() )
-                {
-                    execute( makeglossaries, dir );
-                }
-                if ( bibFile.exists() )
-                {
-                    execute( bibTeX, dir );
-                    execute( pdfLaTeX, dir );
-                }
-
                 for ( int runs = extraRuns + 1; runs > 0; runs-- )
                 {
+                    if ( gloFile.exists() )
+                    {
+                        execute( makeglossaries, dir );
+                    }
+                    if ( bibFile.exists() )
+                    {
+                        execute( bibTeX, dir );
+                        execute( pdfLaTeX, dir );
+                    }
                     execute( pdfLaTeX, dir );
                 }
 


### PR DESCRIPTION
This somewhat works around recursive inclusion of acronyms until bib2gls is ready - cf. http://tex.stackexchange.com/q/352973/43807 - by allowing us to run it repeatedly (reusing the same mechanism we already use for re-running pdflatex to fix hyperrefs and the layout).

Untested but should work as-is.